### PR TITLE
Issue 37 - Allow filtering from bar charts

### DIFF
--- a/nerdlets/mande-nerdlet/components/category-detail/CategoryDetail.js
+++ b/nerdlets/mande-nerdlet/components/category-detail/CategoryDetail.js
@@ -4,8 +4,9 @@ import isEqual from 'lodash.isequal'
 import ChartGrid from './ChartGrid'
 import Metric from '../../../shared/components/metric/Metric'
 import { loadMetricsForConfig } from '../../../shared/utils/metric-data-loader'
+import { withFacetFilterContext } from '../../../shared/context/FacetFilterContext'
 
-export default class CategoryDetail extends React.Component {
+class CategoryDetail extends React.Component {
   state = {
     metricDefs: [],
   }
@@ -29,7 +30,10 @@ export default class CategoryDetail extends React.Component {
 
   async componentDidUpdate(prevProps) {
     if (
-      !isEqual(prevProps.activeFilters, this.props.activeFilters) ||
+      !isEqual(
+        prevProps.facetContext.queryFormattedFilters,
+        this.props.facetContext.queryFormattedFilters
+      ) ||
       prevProps.duration !== this.props.duration ||
       prevProps.stack !== this.props.stack ||
       prevProps.accountId !== this.props.accountId
@@ -63,12 +67,17 @@ export default class CategoryDetail extends React.Component {
   }
 
   loadMetricData = async () => {
-    const { accountId, duration, stack, activeFilters } = this.props
+    const {
+      accountId,
+      duration,
+      stack,
+      facetContext: { queryFormattedFilters },
+    } = this.props
     let metricDefs = await loadMetricsForConfig(
       stack,
       duration,
       accountId,
-      activeFilters
+      queryFormattedFilters
     )
 
     this.setState({ metricDefs })
@@ -81,7 +90,7 @@ export default class CategoryDetail extends React.Component {
       threshold,
       activeMetric,
       toggleMetric,
-      activeFilters,
+      facetContext: { filterQueryString },
     } = this.props
     const { metricDefs } = this.state
 
@@ -116,7 +125,7 @@ export default class CategoryDetail extends React.Component {
                   query={metricDef.def.query.nrql + duration.since}
                   selected={activeMetric === metricDef.def.title}
                   click={toggleMetric}
-                  filters={activeFilters}
+                  filters={filterQueryString}
                   visibleThreshold={threshold}
                   showTooltip={true}
                   valueAlign="left"
@@ -130,7 +139,7 @@ export default class CategoryDetail extends React.Component {
     return metrics
   }
 
-  renderDetailView = (filters, facetClause) => {
+  renderDetailView = () => {
     const {
       accountId,
       duration,
@@ -154,8 +163,6 @@ export default class CategoryDetail extends React.Component {
             duration={duration}
             stack={stack}
             activeMetric={activeMetric}
-            filters={filters}
-            facets={facetClause}
             chartDefs={detailDashboardId.config}
             actionMenuSelect={actionMenuSelect}
           />
@@ -165,8 +172,6 @@ export default class CategoryDetail extends React.Component {
         <ChartGrid
           accountId={accountId}
           duration={duration}
-          filters={filters}
-          facets={facetClause}
           chartDefs={stack.overviewDashboard}
           actionMenuSelect={actionMenuSelect}
       />
@@ -176,8 +181,6 @@ export default class CategoryDetail extends React.Component {
   }
 
   render() {
-    const { activeFilters, facets } = this.props
-
     return (
       <Stack className="detail-container">
         <Stack
@@ -187,10 +190,12 @@ export default class CategoryDetail extends React.Component {
         >
           <StackItem className="detail-kpis">{this.renderMetrics()}</StackItem>
           <StackItem className="detail-main">
-            {this.renderDetailView(activeFilters, facets)}
+            {this.renderDetailView()}
           </StackItem>
         </Stack>
       </Stack>
     )
   }
 }
+
+export default withFacetFilterContext(CategoryDetail)

--- a/nerdlets/mande-nerdlet/components/category-detail/Chart.js
+++ b/nerdlets/mande-nerdlet/components/category-detail/Chart.js
@@ -65,7 +65,7 @@ export default class Chart extends React.Component {
     const { facets } = this.props
     let allFacets = []
 
-    if (config.facets) allFacets = config.facets.split(',')
+    if (config.facets) allFacets = config.facets.split(',').map(item => item.trim())
     if (facets) allFacets = allFacets.concat(facets.split(','))
     const formattedFacets = formatFacets(uniq(allFacets))
 

--- a/nerdlets/mande-nerdlet/components/category-detail/Chart.js
+++ b/nerdlets/mande-nerdlet/components/category-detail/Chart.js
@@ -127,12 +127,14 @@ class Chart extends React.Component {
             accountId={accountId}
             query={query}
             onClickBar={
-              config.click ? getHook(config.click).bind(this.props) : () => null
+              getHook(config.click ? config.click : 'filter').bind(this.props)
+              // config.click ? getHook(config.click).bind(this.props) : () => null
             }
           />
         )
       case 'billboard':
-        if (facets) return <BarChart accountId={accountId} query={query} />
+        if (facets)
+          return this.renderChart({ ...config, chartType: 'bar' }, query)
         else return <BillboardChart accountId={accountId} query={query} />
       case 'heatmap':
         return <HeatmapChart accountId={accountId} query={query} />

--- a/nerdlets/mande-nerdlet/components/category-detail/ChartGrid.js
+++ b/nerdlets/mande-nerdlet/components/category-detail/ChartGrid.js
@@ -3,14 +3,7 @@ import { Grid, GridItem, ChartGroup } from 'nr1'
 import Chart from './Chart'
 
 const chartGrid = props => {
-  const {
-    accountId,
-    duration,
-    filters,
-    facets,
-    chartDefs,
-    actionMenuSelect,
-  } = props
+  const { accountId, duration, chartDefs, actionMenuSelect } = props
 
   return (
     <ChartGroup>
@@ -27,8 +20,6 @@ const chartGrid = props => {
                   <Chart
                     accountId={accountId}
                     duration={duration}
-                    filters={filters}
-                    facets={facets}
                     chartDef={chartDef}
                     actionMenuSelect={actionMenuSelect}
                   />

--- a/nerdlets/mande-nerdlet/components/metric-sidebar/ActiveSidebar.js
+++ b/nerdlets/mande-nerdlet/components/metric-sidebar/ActiveSidebar.js
@@ -1,13 +1,14 @@
 import React from 'react'
 
 import { StackItem } from 'nr1'
+import FacetFilterContext from '../../../shared/context/FacetFilterContext'
 
 const selected = props => {
-  const { showFacets, selected, toggle } = props
+  const { showFacets, items, toggle } = props
 
-  const activeItems =
-    selected &&
-    selected.map((item, idx) => {
+  const itemList =
+    items &&
+    items.map((item, idx) => {
       const value = showFacets ? item : item.value
       return (
         <div className="filter-attribute-item__selected" key={value + idx}>
@@ -32,11 +33,11 @@ const selected = props => {
     })
 
   return (
-    <React.Fragment>
-      {activeItems && activeItems.length > 0 && (
-        <StackItem className="filter-stack selected">{activeItems}</StackItem>
+    <>
+      {items && items.length > 0 && (
+        <StackItem className="filter-stack selected">{itemList}</StackItem>
       )}
-    </React.Fragment>
+    </>
   )
 }
 

--- a/nerdlets/mande-nerdlet/components/metric-sidebar/Facet.js
+++ b/nerdlets/mande-nerdlet/components/metric-sidebar/Facet.js
@@ -1,15 +1,16 @@
 import React from 'react'
 import startCase from 'lodash.startcase'
 import { Checkbox } from 'nr1'
+import { withFacetFilterContext } from '../../../shared/context/FacetFilterContext'
 
 const facet = props => {
-  const { attribute, facetToggle, activeFacets } = props
-
+  const {
+    facetContext: { facets, updateFacets },
+    attribute,
+  } = props
   const displayName = startCase(attribute)
-
-  const selected =
-    activeFacets &&
-    activeFacets.find(facet => facet === attribute) !== undefined
+  const isSelected =
+    facets && facets.find(facet => facet === attribute) !== undefined
 
   return (
     <div className="filter-category-section">
@@ -17,14 +18,14 @@ const facet = props => {
         <h5 className="facet-category-section-label">
           <span className="filter-attribute-checkbox">
             <Checkbox
-              checked={selected}
+              checked={isSelected}
               className="filter-attribute-checkbox-input"
-              onChange={() => facetToggle(attribute, !selected)}
+              onChange={() => updateFacets(attribute, !isSelected)}
             />
           </span>
           <span
             className="facet-category-section-label-text"
-            onClick={() => facetToggle(attribute, !selected)}
+            onClick={() => updateFacets(attribute, !isSelected)}
           >
             {displayName}
           </span>
@@ -34,4 +35,4 @@ const facet = props => {
   )
 }
 
-export default facet
+export default withFacetFilterContext(facet)

--- a/nerdlets/mande-nerdlet/components/metric-sidebar/Facet.js
+++ b/nerdlets/mande-nerdlet/components/metric-sidebar/Facet.js
@@ -20,12 +20,12 @@ const facet = props => {
             <Checkbox
               checked={isSelected}
               className="filter-attribute-checkbox-input"
-              onChange={() => updateFacets(attribute, !isSelected)}
+              onChange={() => updateFacets(attribute)}
             />
           </span>
           <span
             className="facet-category-section-label-text"
-            onClick={() => updateFacets(attribute, !isSelected)}
+            onClick={() => updateFacets(attribute)}
           >
             {displayName}
           </span>

--- a/nerdlets/mande-nerdlet/components/metric-sidebar/Filter.js
+++ b/nerdlets/mande-nerdlet/components/metric-sidebar/Filter.js
@@ -74,20 +74,17 @@ class Filter extends React.Component {
     ) : (
       values.map((value, idx) => {
         const selected = this.getSelectedState(filters, attribute, value)
-        const selectedNextState = !selected
         return (
           <div key={value + idx} className="filter-attribute-item">
             <span className="filter-attribute-checkbox">
               <Checkbox
                 checked={selected}
                 className="filter-attribute-checkbox-input"
-                onChange={() =>
-                  updateFilters(attribute, value, selectedNextState)
-                }
+                onChange={() => updateFilters(attribute, value)}
               />
             </span>
             <span
-              onClick={() => updateFilters(attribute, value, selectedNextState)}
+              onClick={() => updateFilters(attribute, value)}
               className={
                 selected
                   ? 'filter-attribute-value checked'

--- a/nerdlets/mande-nerdlet/index.js
+++ b/nerdlets/mande-nerdlet/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { PlatformStateContext, NerdletStateContext, nerdlet } from 'nr1'
 import MandeContainer from './MandeContainer'
+import { FacetFilterProvider } from '../shared/context/FacetFilterContext'
 
 export default class Wrapper extends React.Component {
   componentDidMount() {
@@ -15,10 +16,12 @@ export default class Wrapper extends React.Component {
         {launcherUrlState => (
           <NerdletStateContext.Consumer>
             {nerdletUrlState => (
-              <MandeContainer
-                launcherUrlState={launcherUrlState}
-                nerdletUrlState={nerdletUrlState}
-              />
+              <FacetFilterProvider>
+                <MandeContainer
+                  launcherUrlState={launcherUrlState}
+                  nerdletUrlState={nerdletUrlState}
+                />
+              </FacetFilterProvider>
             )}
           </NerdletStateContext.Consumer>
         )}

--- a/nerdlets/shared/context/FacetFilterContext.js
+++ b/nerdlets/shared/context/FacetFilterContext.js
@@ -1,0 +1,97 @@
+import React from 'react'
+import cloneDeep from 'lodash.clonedeep'
+import { formatFilters, formatFacets } from '../utils/query-formatter'
+
+const FacetFilterContext = React.createContext()
+
+export class FacetFilterProvider extends React.Component {
+  emptyState = {
+    filters: [],
+    facets: [],
+    queryFormattedFilters: undefined,
+    queryFormattedFacets: '',
+  }
+
+  state = { ...this.emptyState }
+
+  updateFilters = (attribute, value, add) => {
+    let clonedFilters = []
+
+    if (this.state.filters) clonedFilters = cloneDeep(this.state.filters)
+    if (add) {
+      clonedFilters.push({ attribute, value })
+      this.setState({
+        filters: clonedFilters,
+        queryFormattedFilters: formatFilters(clonedFilters),
+      })
+      return
+    }
+
+    let updatedFilters = []
+    if (!add) {
+      updatedFilters = clonedFilters.filter(
+        active => !(active.attribute === attribute && active.value === value)
+      )
+      this.setState({
+        filters: updatedFilters,
+        queryFormattedFilters: formatFilters(updatedFilters),
+      })
+    }
+  }
+
+  updateFacets = (attribute, add) => {
+    const clonedFacets = [...this.state.facets]
+
+    if (add) {
+      clonedFacets.push(attribute)
+      this.setState({
+        facets: clonedFacets,
+        queryFormattedFacets: formatFacets(clonedFacets),
+      })
+      return
+    }
+
+    let updatedFacets = []
+    if (!add) {
+      updatedFacets = clonedFacets.filter(cloned => cloned !== attribute)
+      this.setState({
+        facets: updatedFacets,
+        queryFormattedFacets: formatFacets(updatedFacets),
+      })
+    }
+  }
+
+  reset = () => this.setState({ ...this.emptyState })
+
+  render() {
+    const { children } = this.props
+
+    return (
+      <FacetFilterContext.Provider
+        value={{
+          ...this.state,
+          updateFilters: this.updateFilters,
+          updateFacets: this.updateFacets,
+          reset: this.reset,
+        }}
+      >
+        {children}
+      </FacetFilterContext.Provider>
+    )
+  }
+}
+
+export const FacetFilterConsumer = FacetFilterContext.Consumer
+export default FacetFilterContext
+
+export const withFacetFilterContext = WrappedComponent => {
+  return React.forwardRef((props, ref) => {
+    return (
+      <FacetFilterConsumer>
+        {value => (
+          <WrappedComponent facetContext={value} {...props} ref={ref} />
+        )}
+      </FacetFilterConsumer>
+    )
+  })
+}

--- a/nerdlets/shared/utils/hooks.js
+++ b/nerdlets/shared/utils/hooks.js
@@ -5,9 +5,28 @@ const hooks = [
     name: 'openSession',
     handler({ data, metadata }) {
       if (!this || !this.accountId)
-        throw `This handler's this context must be bound to the calling props`
+        console.error(
+          `This handler's this context must be bound to the calling props`
+        )
 
       openVideoSession(this.accountId, metadata.name)
+    },
+  },
+  {
+    name: 'filter',
+    handler({ data, metadata }) {
+      if (!this) console.error(`Please bind the appropriate this context`)
+
+      if (!this.facetContext)
+        console.error(
+          `A FilterFacetContext is expected to be found in the bound this context`
+        )
+
+      const filterGroups = metadata.groups.filter(
+        group => group.type === 'facet'
+      )
+
+      this.facetContext.updateFilterGroup(filterGroups)
     },
   },
 ]


### PR DESCRIPTION
Allow filters to be selected/deselected by clicking on a row in a faceted bar chart.

This revision includes refactoring the facet/filter state tracking into a shareable context rather than by prop drililng.