### PR TITLE
feat: add missing video timeline actions

### DIFF
--- a/nerdlets/video-session/components/timeline/VideoGroup.js
+++ b/nerdlets/video-session/components/timeline/VideoGroup.js
@@ -51,6 +51,7 @@ const groups = [
       'CONTENT_SEEK_END',
       'CONTENT_DROPPED_FRAMES',
       'CONTENT_NEXT',
+      'CONTENT_MANIFEST_REQUEST',
     ],
   },
   {
@@ -148,6 +149,20 @@ const groups = [
       label: 'External Calls',
     },
     actionNames: ['UNKNOWN AT THIS TIME'],
+  },
+  {
+    name: 'DEVICE',
+    eventDisplay: {
+      class: 'timeline-item-type-device',
+      icon: Icon.TYPE.HARDWARE_AND_SOFTWARE__HARDWARE__MOBILE,
+      label: 'Device',
+      color: '#9055cf',
+    },
+    timelineDisplay: {
+      color: '#9055cf', // purple
+      label: 'Device',
+    },
+    actionNames: ['FOREGROUND', 'BACKGROUND'],
   },
 ]
 

--- a/nerdlets/video-session/components/timeline/styles.scss
+++ b/nerdlets/video-session/components/timeline/styles.scss
@@ -82,6 +82,10 @@
   background-color: #add7f7;
 }
 
+.timeline-item-type-device .timeline-item-symbol:after {
+  background-color: #f6ccfc;
+}
+
 .timeline-item-type-general .timeline-item-symbol-icon {
   display: none;
 }


### PR DESCRIPTION
Video timeline was not properly displaying the following groups:
- FOREGROUND, BACKGROUND, CONTENT_MANIFEST_REQUEST