### PR TITLE
fix: session detail breaks without a metric threshold definition

### DIFF
--- a/nerdlets/find-user/components/session/SessionContainer.js
+++ b/nerdlets/find-user/components/session/SessionContainer.js
@@ -50,7 +50,7 @@ export default class SessionContainer extends React.Component {
     if (view.def.qualityScoreStrategy) {
       view.qualityScore = metricQualityScore(
         view.value,
-        view.def.threshold.critical,
+        view.def.threshold ? view.def.threshold.critical : null,
         view.def.qualityScoreStrategy
       )
     }

--- a/nerdlets/shared/utils/quality-score.js
+++ b/nerdlets/shared/utils/quality-score.js
@@ -3,7 +3,8 @@ import { roundToTwoDigits } from './number-formatter'
 export const metricQualityScore = (metric, threshold, strategy) => {
   switch (strategy) {
     case 'clampMinZeroMaxOne':
-      return metric >= threshold ? 0 : 1
+      if (threshold) return metric >= threshold ? 0 : 1
+      else return 1
     case 'zeroOrOne':
       if (metric && metric > 0) return 0
       else return 1


### PR DESCRIPTION
Add handling to accept null threshold definitions for KPIs that contribute to the overall QoS score for a view. KPIs with missing thresholds will alway return a result of a passing quality score.