### PR TITLE
refresh filter values on demand

### DIFF
--- a/nerdlets/mande-nerdlet/components/action-sidebar/Filter.js
+++ b/nerdlets/mande-nerdlet/components/action-sidebar/Filter.js
@@ -40,11 +40,6 @@ class Filter extends React.Component {
     if (shouldQuery) this.setState({ loading: true }, this.queryValues)
   }
 
-  refreshValues = evt => {
-    evt.stopPropagation()
-    this.loadValues(true)
-  }
-
   queryValues = async () => {
     const {
       accountId,
@@ -101,6 +96,11 @@ class Filter extends React.Component {
     }
 
     this.setState({ searchText, searchRE, displayValues })
+  }
+
+  refreshHandler = evt => {
+    evt.stopPropagation()
+    this.loadValues(true)
   }
 
   render() {
@@ -167,7 +167,7 @@ class Filter extends React.Component {
                 {displayName}
               </span>
               <span className="filter-category-section-label-control">
-                <span onClick={this.refreshValues}>
+                <span onClick={this.refreshHandler}>
                   <Icon type={Icon.TYPE.INTERFACE__OPERATIONS__REFRESH} />
                 </span>
                 <span>{chevronIcon}</span>

--- a/nerdlets/mande-nerdlet/components/action-sidebar/Filter.js
+++ b/nerdlets/mande-nerdlet/components/action-sidebar/Filter.js
@@ -40,6 +40,11 @@ class Filter extends React.Component {
     if (shouldQuery) this.setState({ loading: true }, this.queryValues)
   }
 
+  refreshValues = evt => {
+    evt.stopPropagation()
+    this.loadValues(true)
+  }
+
   queryValues = async () => {
     const {
       accountId,
@@ -47,6 +52,7 @@ class Filter extends React.Component {
       eventTypes,
       duration: { since },
     } = this.props
+    const { searchText, displayValues } = this.state
 
     const query = `SELECT uniques(${attribute}) FROM ${eventTypes} ${since}`
 
@@ -60,7 +66,7 @@ class Filter extends React.Component {
       loading: false,
       lastLoad: Date.now(),
       values,
-      displayValues: values,
+      displayValues: searchText.trim().length ? displayValues : values,
     })
   }
 
@@ -87,10 +93,9 @@ class Filter extends React.Component {
     try {
       const trimmedSearchText = searchText.trim()
       searchRE = new RegExp(trimmedSearchText, 'ig')
-      displayValues =
-        trimmedSearchText.length > 0
-          ? values.filter(value => searchRE.test(value))
-          : values
+      displayValues = trimmedSearchText.length
+        ? values.filter(value => searchRE.test(value))
+        : values
     } catch (e) {
       console.error(`Unable to search for filter values. ${e.message}`)
     }
@@ -161,7 +166,12 @@ class Filter extends React.Component {
               <span className="filter-category-section-label-text">
                 {displayName}
               </span>
-              {chevronIcon}
+              <span className="filter-category-section-label-control">
+                <span onClick={this.refreshValues}>
+                  <Icon type={Icon.TYPE.INTERFACE__OPERATIONS__REFRESH} />
+                </span>
+                <span>{chevronIcon}</span>
+              </span>
             </React.Fragment>
           </h5>
         </div>

--- a/nerdlets/mande-nerdlet/components/action-sidebar/style.scss
+++ b/nerdlets/mande-nerdlet/components/action-sidebar/style.scss
@@ -151,6 +151,13 @@ div[class*="wnd-StackItem"].filters-container-stack-item {
   }
 }
 
+.filter-category-section-label-control {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 2em;
+}
+
 .filter-stack {
   width: 100%;
   margin-bottom: 5px;


### PR DESCRIPTION
fixes #41

- add a refresh button to each attribute under filters
- clicking button forces a refresh of the values for that attribute
-  updated the `queryValues` function to account for any search in-progress (without this, when the values are refreshed, it displays all values, even if some search text was entered)
- updated an [unrelated line of code](https://github.com/newrelic/nr1-mande/compare/develop...amit-y:filter-values-refresh?expand=1#diff-70dfe0ba000169150559217a499253983320ea975446a7c66d48fe177cafcc10L91) to keep it consistent with similar check included in this PR