### PR TITLE
contains option for filtering

### DIFF
--- a/nerdlets/mande-nerdlet/components/action-sidebar/style.scss
+++ b/nerdlets/mande-nerdlet/components/action-sidebar/style.scss
@@ -237,8 +237,13 @@ div[class*="wnd-StackItem"] {
 }
 
 .filter-values-list {
+  min-height: 10px;
   max-height: 200px;
   overflow-y: scroll;
+
+  div[role=progressbar]::before {
+    margin-top: 0;
+  }
 }
 
 .filter-attribute-item, .filter-search {

--- a/nerdlets/shared/utils/query-formatter.js
+++ b/nerdlets/shared/utils/query-formatter.js
@@ -20,10 +20,16 @@ export const formatSinceAndCompare = timeRange => {
 
 const singleFilter = (attribute, value) => {
   const isString = isStringValue(value)
-  const prefix = `WHERE ${getAttribute(attribute, isString)} =`
+  const prefix = ` WHERE ${getAttribute(attribute, isString)} `
+  const contains = [...value.matchAll(/contains "(.*)"/g)]
+  if (contains.length && contains[0].length)
+    return {
+      single: `${prefix} LIKE '%${escapeValue(contains[0][1])}%' `,
+      double: `${prefix} LIKE '%${doubleEscapeValue(contains[0][1])}%' `,
+    }
   const filters = {
-    single: `${prefix} ${getFilterValue(value, isString, 'single')} `,
-    double: `${prefix} ${getFilterValue(value, isString, 'double')} `,
+    single: `${prefix} = ${getFilterValue(value, isString, 'single')} `,
+    double: `${prefix} = ${getFilterValue(value, isString, 'double')} `,
   }
   return filters
 }
@@ -31,22 +37,40 @@ const singleFilter = (attribute, value) => {
 const multipleFilters = (attribute, values) => {
   const isString = isStringValue(values)
 
-  let singleEscapedValues = ''
-  let doubleEscapedValues = ''
-  for (let i = 1; i <= values.length; i++) {
-    singleEscapedValues = singleEscapedValues + getFilterValue(values[i - 1], isString, 'single')
-    if (i < values.length) singleEscapedValues = singleEscapedValues + ','
+  const queryAttribute = getAttribute(attribute, isString)
+  const queryValues = values.reduce(
+    (acc, value) => {
+      const contains = [...value.matchAll(/contains "(.*)"/g)]
+      if (contains.length && contains[0].length) {
+        acc.contains = {
+          single: `OR ${queryAttribute} LIKE '%${escapeValue(
+            contains[0][1]
+          )}%'`,
+          double: `OR ${queryAttribute} LIKE '%${doubleEscapeValue(
+            contains[0][1]
+          )}%'`,
+        }
+      } else {
+        acc.singleEscapedValues.push(getFilterValue(value, isString, 'single'))
+        acc.doubleEscapedValues.push(getFilterValue(value, isString, 'double'))
+      }
+      return acc
+    },
+    {
+      singleEscapedValues: [],
+      doubleEscapedValues: [],
+      contains: { single: '', double: '' },
+    }
+  )
 
-    doubleEscapedValues = doubleEscapedValues + getFilterValue(values[i - 1], isString, 'double')
-    if (i < values.length) doubleEscapedValues = doubleEscapedValues + ','
-  }
+  let single = ` WHERE ${queryAttribute} `, double = single
+  single += ` IN (${queryValues.singleEscapedValues.join(',')}) `
+  single += `${queryValues.contains.single} `
+  
+  double += ` IN (${queryValues.doubleEscapedValues.join(',')}) `
+  double += `${queryValues.contains.double} `
 
-  const prefix = ` WHERE ${getAttribute(attribute, isString)} IN (`
-  const suffix = ')'
-  return {
-    single: `${prefix} ${singleEscapedValues} ${suffix}`,
-    double: `${prefix} ${doubleEscapedValues} ${suffix}`,
-  }
+  return { single, double }
 }
 
 const getAttribute = (attribute, isString) => {
@@ -65,7 +89,7 @@ const getFilterValue = (value, isString, escapeType) => {
 }
 
 const escapeValue = value => {
-  return value.replace(/'/g, "\\\'")
+  return value.replace(/'/g, "\\'")
 }
 
 const doubleEscapeValue = value => {

--- a/nerdlets/shared/utils/query-formatter.js
+++ b/nerdlets/shared/utils/query-formatter.js
@@ -66,7 +66,7 @@ const multipleFilters = (attribute, values) => {
   let single = ` WHERE ${queryAttribute} `, double = single
   single += ` IN (${queryValues.singleEscapedValues.join(',')}) `
   single += `${queryValues.contains.single} `
-  
+
   double += ` IN (${queryValues.doubleEscapedValues.join(',')}) `
   double += `${queryValues.contains.double} `
 
@@ -89,7 +89,7 @@ const getFilterValue = (value, isString, escapeType) => {
 }
 
 const escapeValue = value => {
-  return value.replace(/'/g, "\\'")
+  return value.replace(/'/g, "\\\'")
 }
 
 const doubleEscapeValue = value => {


### PR DESCRIPTION
Fixes #79 

- adds a contains option when user searches for filters within an attribute

Other minor fixes included:
- since `searchText.trim()` was being used in multiple locations, saving it to a state variable, and reusing state variable when needed
- fixes the progress bar when searching for filter values (css fix only)