### PR TITLE
fix: find user endless retry loop

### DIFF
--- a/nerdlets/shared/utils/metric-data-loader.js
+++ b/nerdlets/shared/utils/metric-data-loader.js
@@ -51,7 +51,8 @@ export const loadMetricsForConfig = async (
             parser,
             queryCategory
           )
-          if (!dataDef || !Object.keys(dataDef).length) {
+          // if (!dataDef || !Object.keys(dataDef).length) {
+          if (!dataDef || dataDef.error) {
             metricNoData.push(metric)
             return null
           }
@@ -122,13 +123,13 @@ export const loadMetric = async (
 
     if (errors) {
       console.error(`error returned by query. ${query}: `, errors)
-      return {}
+      return { error: true }
     } else {
       return parser(metric, data, metric[queryCategory].lookup)
     }
   } catch (e) {
     console.error(`error occurred: `, e)
-    return {}
+    return { error: true }
   }
 }
 


### PR DESCRIPTION
Fix situation where a metric query that returns no result causes an endless retry loop.