### PR TITLE
refactor: update configs to use nerdstore

### DIFF
--- a/nerdlets/find-user/FindUserContainer.js
+++ b/nerdlets/find-user/FindUserContainer.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Stack, StackItem, HeadingText } from 'nr1'
 import SearchBar from './components/search-bar/SearchBar'
 import SessionContainer from './components/session/SessionContainer'
-import videoConfig from '../shared/config/VideoConfig'
+import { loadMetricsConfigs } from '../shared/utils/metric-config-loader'
 import { formatSinceAndCompare } from '../shared/utils/query-formatter'
 import {
   openUserVideoViews,
@@ -12,6 +12,12 @@ import {
 export default class FindUserContainer extends React.Component {
   state = {
     user: '',
+  }
+
+  async componentDidMount() {
+    const { nerdletUrlState: {accountId} = {} } = this.props
+    const videoConfig = await loadMetricsConfigs(accountId, 'Video')
+    this.setState({videoConfig})
   }
 
   onSelectUser = async user => {
@@ -57,10 +63,11 @@ export default class FindUserContainer extends React.Component {
 
   onChooseSession = (item, scope) => {
     const { accountId, user } = this.props.nerdletUrlState
+    const { videoConfig } = this.state
     scope = scope ? scope : 'all'
 
     if (item.views.length === 1) {
-      openVideoSession(accountId, item.views[0].id, videoConfig.title)
+      openVideoSession(accountId, item.views[0].id, (videoConfig || {}).title)
     } else {
       openUserVideoViews(
         accountId,
@@ -77,6 +84,7 @@ export default class FindUserContainer extends React.Component {
     const { timeRange } = this.props.launcherUrlState
     const { accountId } = this.props.nerdletUrlState
     const duration = formatSinceAndCompare(timeRange)
+    const { videoConfig } = this.state
 
     return (
       <Stack
@@ -121,6 +129,7 @@ export default class FindUserContainer extends React.Component {
         {user && (
           <StackItem style={{ height: '100%' }}>
             <SessionContainer
+              videoConfig={videoConfig}
               accountId={accountId}
               duration={duration}
               user={user}

--- a/nerdlets/find-user/components/session/SessionContainer.js
+++ b/nerdlets/find-user/components/session/SessionContainer.js
@@ -8,7 +8,6 @@ import {
   loadMetricsForConfig,
   facetParser,
 } from '../../../shared/utils/metric-data-loader'
-import videoConfig from '../../../shared/config/VideoConfig'
 import {
   metricQualityScore,
   viewQualityScore,
@@ -25,7 +24,7 @@ export default class SessionContainer extends React.Component {
   }
 
   loadData = async () => {
-    const { accountId, duration, user } = this.props
+    const { videoConfig, accountId, duration, user } = this.props
 
     let userClause = ''
     FIND_USER_ATTRIBUTE.forEach(u => {
@@ -95,6 +94,7 @@ export default class SessionContainer extends React.Component {
   }
 
   loadSessions = async () => {
+    const { videoConfig } = this.props
     const data = await this.loadData()
 
     let sessionViews = []
@@ -162,7 +162,7 @@ export default class SessionContainer extends React.Component {
   }
 
   render() {
-    const { user, duration, accountId, chooseSession } = this.props
+    const { videoConfig, user, duration, accountId, chooseSession } = this.props
     const { loading, userKpis, sessionViews } = this.state
     const formattedDuration = dateFormatter(duration.timeRange)
 
@@ -190,20 +190,25 @@ export default class SessionContainer extends React.Component {
                     </HeadingText>
                   </StackItem>
 
-                  <QosKpiGrid
-                    qualityScore={sessionViews.qualityScore}
-                    kpis={userKpis}
-                    threshold={videoConfig.qualityScore.threshold}
-                  />
+                  {videoConfig ? (
+                    <QosKpiGrid
+                      qualityScore={sessionViews.qualityScore}
+                      kpis={userKpis}
+                      threshold={videoConfig.qualityScore.threshold}
+                    />
+                  ) : null}
 
                   <div className="session-table">
-                    <SessionTable
-                      accountId={accountId}
-                      user={user}
-                      duration={duration}
-                      sessionViews={sessionViews}
-                      chooseSession={chooseSession}
-                    />
+                    {videoConfig ? (
+                      <SessionTable
+                        videoConfig={videoConfig}
+                        accountId={accountId}
+                        user={user}
+                        duration={duration}
+                        sessionViews={sessionViews}
+                        chooseSession={chooseSession}
+                      />
+                    ) : null}
                   </div>
                 </div>
               </React.Fragment>
@@ -216,6 +221,7 @@ export default class SessionContainer extends React.Component {
 }
 
 SessionContainer.propTypes = {
+  videoConfig: PropTypes.object,
   duration: PropTypes.object.isRequired,
   accountId: PropTypes.number.isRequired,
   user: PropTypes.string.isRequired,

--- a/nerdlets/find-user/components/session/SessionTable.js
+++ b/nerdlets/find-user/components/session/SessionTable.js
@@ -17,8 +17,10 @@ import {
   milliseconds,
 } from '../../../shared/utils/date-formatter'
 import { getThresholdClass } from '../../../shared/utils/threshold'
-import videoConfig from '../../../shared/config/VideoConfig'
-import { FIND_USER_ATTRIBUTE, VIDEO_EVENTS } from '../../../shared/config/constants'
+import {
+  FIND_USER_ATTRIBUTE,
+  VIDEO_EVENTS,
+} from '../../../shared/config/constants'
 
 export default class SessionTable extends React.Component {
   state = {
@@ -27,7 +29,8 @@ export default class SessionTable extends React.Component {
   }
 
   getViewQualityCount = (views, threshold, above) => {
-    const count = views.reduce((acc, v) => {
+    const count = views.reduce(
+      (acc, v) => {
         if (
           (above && v.qualityScore >= threshold) ||
           (!above && v.qualityScore < threshold)
@@ -69,7 +72,7 @@ export default class SessionTable extends React.Component {
   }
 
   render() {
-    const { accountId, duration, user, sessionViews } = this.props
+    const { videoConfig, accountId, duration, user, sessionViews } = this.props
 
     let userClause = ''
     FIND_USER_ATTRIBUTE.forEach(u => {
@@ -104,7 +107,10 @@ export default class SessionTable extends React.Component {
             const timedSession = {
               session: s.session,
               qualityScore: s.qualityScore,
-              totalViews: s.views.reduce((acc, v) => { acc.push(v.id); return acc }, []),
+              totalViews: s.views.reduce((acc, v) => {
+                acc.push(v.id)
+                return acc
+              }, []),
               good: this.getViewQualityCount(s.views, 90, true),
               bad: this.getViewQualityCount(s.views, 90, false),
               minTime,
@@ -199,11 +205,15 @@ export default class SessionTable extends React.Component {
                     {formatTimeAsString(item.duration, milliseconds)}
                   </TableRowCell>
                   <TableRowCell
-                    className={`session-table__row bold ${getThresholdClass(
-                      videoConfig.qualityScore.threshold,
-                      item.qualityScore,
-                      'greenLight'
-                    )}`}
+                    className={`session-table__row bold ${
+                      videoConfig
+                        ? getThresholdClass(
+                            videoConfig.qualityScore.threshold,
+                            item.qualityScore,
+                            'greenLight'
+                          )
+                        : ''
+                    }`}
                   >
                     {item.qualityScore + ' %'}
                   </TableRowCell>
@@ -227,6 +237,7 @@ export default class SessionTable extends React.Component {
 }
 
 SessionTable.propTypes = {
+  videoConfig: PropTypes.object,
   duration: PropTypes.object.isRequired,
   accountId: PropTypes.number.isRequired,
   user: PropTypes.string.isRequired,

--- a/nerdlets/shared/utils/metric-config-loader.js
+++ b/nerdlets/shared/utils/metric-config-loader.js
@@ -1,0 +1,49 @@
+import { AccountStorageQuery, AccountStorageMutation } from 'nr1'
+import * as metricConfigsDefault from '../config/MetricConfig'
+
+let configs = []
+const collection = 'metricConfigs'
+
+export const loadMetricsConfigs = async (accountId, type) => {
+  let metricConfigs
+  // UNCOMMENT BELOW SECTION TO DELETE CONFIGS FROM NERDSTORE
+  // const del = await AccountStorageMutation.mutate({
+  //   accountId,
+  //   actionType: AccountStorageMutation.ACTION_TYPE.DELETE_COLLECTION,
+  //   collection,
+  // })
+
+  if (configs.length) {
+    console.log('loading configs from memory')
+    metricConfigs = configs
+  } else {
+    const { data: configStorageCollection } = await AccountStorageQuery.query({
+      accountId,
+      collection,
+    })
+    if (configStorageCollection.length) {
+      console.log('loading configs from nerdstore')
+      configs = configStorageCollection.map(doc => doc.document)
+      metricConfigs = configs
+    } else {
+      console.log('loading configs from defaults')
+      configs = metricConfigsDefault.default
+      console.log(configs)
+      configs.map(
+        async (config, idx) =>
+          await AccountStorageMutation.mutate({
+            accountId,
+            actionType: AccountStorageMutation.ACTION_TYPE.WRITE_DOCUMENT,
+            collection,
+            documentId: `doc${idx}`,
+            document: config,
+          })
+      )
+      metricConfigs = configs
+    }
+  }
+  
+  return type
+    ? metricConfigs.filter(conf => conf.title === type)[0]
+    : metricConfigs
+}

--- a/nerdlets/shared/utils/metric-data-loader.js
+++ b/nerdlets/shared/utils/metric-data-loader.js
@@ -40,7 +40,7 @@ export const loadMetricsForConfig = async (
   metricData = metricData.concat(
     await Promise.all(
       metricConfig.metrics
-        .filter(metric => metric.query)
+        .filter(metric => (metric || {}).query)
         .map(async metric => {
           let dataDef = await loadMetric(
             metric,

--- a/nerdlets/shared/utils/number-formatter.js
+++ b/nerdlets/shared/utils/number-formatter.js
@@ -2,3 +2,6 @@
 export const roundToTwoDigits = value => {
   return Math.round((value + Number.EPSILON) * 100) / 100
 }
+
+export const defaultTo = (num, def) =>
+  typeof num === 'number' && isFinite(num) ? num : def

--- a/nerdlets/user-video-view/UserViewContainer.js
+++ b/nerdlets/user-video-view/UserViewContainer.js
@@ -3,11 +3,13 @@ import { Stack, StackItem, HeadingText } from 'nr1'
 import { formatSinceAndCompare } from '../shared/utils/query-formatter'
 import { dateFormatter } from '../shared/utils/date-formatter'
 import QosKpiGrid from '../shared/components/qos/QosKpiGrid'
-import videoConfig from '../shared/config/VideoConfig'
+import { loadMetricsConfigs } from '../shared/utils/metric-config-loader'
 import ViewTable from './components/view/ViewTable'
 
 export default class UserViewContainer extends React.Component {
-  collectViewKpis = views => {
+  state = {}
+
+  collectViewKpis = (views, videoConfig) => {
     let kpis = []
     views.forEach(view => {
 
@@ -34,6 +36,12 @@ export default class UserViewContainer extends React.Component {
     return kpis
   }
 
+  async componentDidMount() {
+    const { nerdletUrlState: {accountId} = {} } = this.props
+    const videoConfig = await loadMetricsConfigs(accountId, 'Video')
+    this.setState({videoConfig})
+  }
+
   render() {
     const { timeRange } = this.props.launcherUrlState
     const {
@@ -44,6 +52,7 @@ export default class UserViewContainer extends React.Component {
       scope,
     } = this.props.nerdletUrlState
     const duration = formatSinceAndCompare(timeRange)
+    const { videoConfig } = this.state
 
     return (
       <>
@@ -66,14 +75,15 @@ export default class UserViewContainer extends React.Component {
                 </HeadingText>
               </StackItem>
 
-              <QosKpiGrid
+              {videoConfig ? <QosKpiGrid
                 qualityScore={session.qualityScore}
-                kpis={this.collectViewKpis(views)}
+                kpis={this.collectViewKpis(views, videoConfig)}
                 threshold={videoConfig.qualityScore.threshold}
-              />
+              /> : null}
 
               <div className="session-table">
                 <ViewTable
+                  videoConfig={videoConfig}
                   accountId={accountId}
                   duration={duration}
                   session={session}

--- a/nerdlets/video-session/SessionContainer.js
+++ b/nerdlets/video-session/SessionContainer.js
@@ -2,40 +2,49 @@ import React from 'react'
 import { Grid, GridItem, HeadingText } from 'nr1'
 import SessionDetail from './components/session-detail/SessionDetail'
 import TimelineDetail from './components/timeline/TimelineDetail'
-import videoConfig from '../shared/config/VideoConfig'
+import { loadMetricsConfigs } from '../shared/utils/metric-config-loader'
 import { formatSinceAndCompare } from '../shared/utils/query-formatter'
 
-const sessionContainer = props => {
-  const { timeRange } = props.launcherUrlState
-  const { accountId, session } = props.nerdletUrlState
-  const duration = formatSinceAndCompare(timeRange)
+export default class sessionContainer extends React.Component {
+  state = {}
 
-  return (
-    <Grid style={{ paddingLeft: '1rem' }}>
-      <GridItem columnSpan={12}>
-        <header className="header">
-          <HeadingText type={HeadingText.TYPE.HEADING_3}>
-            View Id {session}
-          </HeadingText>
-        </header>
-      </GridItem>
-      <GridItem columnSpan={4} className="sessionColumn">
-        <SessionDetail
-          accountId={accountId}
-          session={session}
-          stack={videoConfig}
-          duration={duration}
-        />
-      </GridItem>
-      <GridItem columnSpan={8}>
-        <TimelineDetail
-          accountId={accountId}
-          session={session}
-          duration={duration}
-        />
-      </GridItem>
-    </Grid>
-  )
+  async componentDidMount() {
+    const { nerdletUrlState: {accountId} = {} } = this.props
+    const videoConfig = await loadMetricsConfigs(accountId, 'Video')
+    this.setState({videoConfig})
+  }
+
+  render() {
+    const { timeRange } = this.props.launcherUrlState
+    const { accountId, session } = this.props.nerdletUrlState
+    const duration = formatSinceAndCompare(timeRange)
+    const { videoConfig } = this.state
+
+    return (
+      <Grid style={{ paddingLeft: '1rem' }}>
+        <GridItem columnSpan={12}>
+          <header className="header">
+            <HeadingText type={HeadingText.TYPE.HEADING_3}>
+              View Id {session}
+            </HeadingText>
+          </header>
+        </GridItem>
+        <GridItem columnSpan={4} className="sessionColumn">
+          {videoConfig ? <SessionDetail
+            accountId={accountId}
+            session={session}
+            stack={videoConfig}
+            duration={duration}
+          /> : null}
+        </GridItem>
+        <GridItem columnSpan={8}>
+          <TimelineDetail
+            accountId={accountId}
+            session={session}
+            duration={duration}
+          />
+        </GridItem>
+      </Grid>
+    )
+  }
 }
-
-export default sessionContainer


### PR DESCRIPTION
This PR updates how configs are fetched within the nerdpack. Configs were previously stored in modules and imported when needed. The new approach creates a `loadMetricsConfigs` function in `nerdlets/shared/utils/metrics-config-loader.js`. To fetch configs, use the following code:

```
import { loadMetricsConfigs } from '../shared/utils/metric-config-loader' // UPDATE PATH ACCORDINGLY
const metricConfigs = await loadMetricsConfigs(accountId)
```

To fetch a specific config (for example, the video config), use:

```
const videoConfig = await loadMetricsConfigs(accountId, 'Video')
```